### PR TITLE
Feature 13.a: Add bottom navigation bar with 4-tab architecture

### DIFF
--- a/PR Bar Code/Assets/feature_enhancements.md
+++ b/PR Bar Code/Assets/feature_enhancements.md
@@ -42,3 +42,14 @@
 
 11. **Cross-Platform Support:**
     - Consider expanding the app to other platforms, such as Android, to reach a wider audience. 
+
+12. **Bugs**
+    - Badge not removing when notification seen
+    - Notification for new results not been created.  Possibly due to checking for new results not working
+    
+13. **New Features**
+    - a. Add bottom navigation bar.  Have 4 icons.  Me. Family & Friends?. Events and Settings.  Move multi user selecter to Family view.  Keep Me to default user.  Consider adding simple table of most recent results for each user.
+    - b. Move notification to settings window
+    - c. Move dark mode settings to settings screen.  Add auto switch.
+    - d. Multi user support for watch
+    

--- a/PR Bar Code/Models/ParkrunInfo.swift
+++ b/PR Bar Code/Models/ParkrunInfo.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SwiftData
 
 @Model
-class ParkrunInfo {
+class ParkrunInfo: Identifiable {
     @Attribute(.unique) var parkrunID: String
     var name: String
     var homeParkrun: String
@@ -23,6 +23,8 @@ class ParkrunInfo {
     var isDefault: Bool = false // Default user loaded on app startup
     var displayName: String = "" // Computed display name for UI
     var createdDate: Date = Date()
+    
+    var id: String { parkrunID } // Identifiable conformance
 
     init(parkrunID: String, name: String, homeParkrun: String, country: Int? = nil, totalParkruns: String? = nil, lastParkrunDate: String? = nil, lastParkrunTime: String? = nil, lastParkrunEvent: String? = nil, lastParkrunEventURL: String? = nil, isDefault: Bool = false) {
         self.parkrunID = parkrunID

--- a/PR Bar Code/PR_Bar_CodeApp.swift
+++ b/PR Bar Code/PR_Bar_CodeApp.swift
@@ -16,7 +16,7 @@ struct PR_Bar_CodeApp: App {
     
     var body: some Scene {
         WindowGroup {
-            QRCodeBarcodeView()
+            MainTabView()
                 .environmentObject(notificationManager)
                 .onAppear {
                     setupNotifications()

--- a/PR Bar Code/Views/EventsTabView.swift
+++ b/PR Bar Code/Views/EventsTabView.swift
@@ -1,0 +1,104 @@
+//
+//  EventsTabView.swift
+//  PR Bar Code
+//
+//  Created by Claude Code on 15/06/2025.
+//
+
+import SwiftUI
+
+struct EventsTabView: View {
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 30) {
+                Spacer()
+                
+                // Coming Soon Icon
+                Image(systemName: "calendar.badge.clock")
+                    .font(.system(size: 80))
+                    .foregroundColor(.adaptiveParkrunGreen)
+                
+                // Coming Soon Text
+                VStack(spacing: 12) {
+                    Text("Coming Soon")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .foregroundColor(.primary)
+                    
+                    Text("Event Discovery")
+                        .font(.title2)
+                        .fontWeight(.medium)
+                        .foregroundColor(.adaptiveParkrunGreen)
+                    
+                    Text("We're working on exciting features to help you discover local parkrun events, view event information, and find new places to run.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                }
+                
+                // Feature preview cards
+                VStack(spacing: 16) {
+                    FeaturePreviewCard(
+                        icon: "location.magnifyingglass",
+                        title: "Find Local Events",
+                        description: "Discover parkrun events near you"
+                    )
+                    
+                    FeaturePreviewCard(
+                        icon: "info.circle",
+                        title: "Event Details",
+                        description: "View course maps, facilities, and more"
+                    )
+                    
+                    FeaturePreviewCard(
+                        icon: "magnifyingglass",
+                        title: "Search Events",
+                        description: "Search for specific parkrun locations"
+                    )
+                }
+                .padding(.horizontal, 20)
+                
+                Spacer()
+                Spacer()
+            }
+            .navigationTitle("Events")
+            .background(Color(.systemGroupedBackground))
+        }
+    }
+}
+
+struct FeaturePreviewCard: View {
+    let icon: String
+    let title: String
+    let description: String
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundColor(.adaptiveParkrunGreen)
+                .frame(width: 30, height: 30)
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                
+                Text(description)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+        }
+        .padding()
+        .background(Color.adaptiveCardBackground)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
+}
+
+#Preview {
+    EventsTabView()
+}

--- a/PR Bar Code/Views/FamilyTabView.swift
+++ b/PR Bar Code/Views/FamilyTabView.swift
@@ -17,7 +17,6 @@ struct FamilyTabView: View {
     @State private var showAddUser = false
     @State private var showUserSelection = false
     @State private var selectedUserForQR: ParkrunInfo?
-    @State private var showQRCodeSheet = false
     
     private var availableUsers: [ParkrunInfo] {
         parkrunInfoList.sorted { $0.createdDate < $1.createdDate }
@@ -67,7 +66,6 @@ struct FamilyTabView: View {
                                 user: user,
                                 onTapQR: {
                                     selectedUserForQR = user
-                                    showQRCodeSheet = true
                                 },
                                 onDelete: {
                                     deleteUser(user)
@@ -129,10 +127,13 @@ struct FamilyTabView: View {
                 }
             )
         }
-        .sheet(isPresented: $showQRCodeSheet) {
-            if let user = selectedUserForQR {
-                FamilyQRCodeView(user: user, isPresented: $showQRCodeSheet)
-            }
+        .sheet(item: $selectedUserForQR, onDismiss: {
+            selectedUserForQR = nil
+        }) { user in
+            FamilyQRCodeView(user: user, isPresented: Binding(
+                get: { selectedUserForQR != nil },
+                set: { _ in selectedUserForQR = nil }
+            ))
         }
         .onAppear {
             // Data correction: Fix corrupted names (one-time fix)

--- a/PR Bar Code/Views/FamilyTabView.swift
+++ b/PR Bar Code/Views/FamilyTabView.swift
@@ -1,0 +1,619 @@
+//
+//  FamilyTabView.swift
+//  PR Bar Code
+//
+//  Created by Claude Code on 15/06/2025.
+//
+
+import SwiftUI
+import SwiftData
+import CoreImage.CIFilterBuiltins
+
+struct FamilyTabView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var parkrunInfoList: [ParkrunInfo]
+    @EnvironmentObject var notificationManager: NotificationManager
+    
+    @State private var showAddUser = false
+    @State private var showUserSelection = false
+    @State private var selectedUserForQR: ParkrunInfo?
+    @State private var showQRCodeSheet = false
+    
+    private var availableUsers: [ParkrunInfo] {
+        parkrunInfoList.sorted { $0.createdDate < $1.createdDate }
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                if parkrunInfoList.isEmpty {
+                    // Empty state
+                    VStack(spacing: 20) {
+                        Image(systemName: "person.2.badge.plus")
+                            .font(.system(size: 60))
+                            .foregroundColor(.adaptiveParkrunGreen)
+                        
+                        Text("No Family Members")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                        
+                        Text("Add family members and friends to track their parkrun progress together.")
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                        
+                        Button(action: {
+                            showAddUser = true
+                        }) {
+                            HStack {
+                                Image(systemName: "plus.circle.fill")
+                                Text("Add First Member")
+                            }
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color.adaptiveParkrunGreen)
+                            .cornerRadius(12)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.systemGroupedBackground))
+                } else {
+                    // Results table
+                    List {
+                        ForEach(availableUsers, id: \.parkrunID) { user in
+                            FamilyUserCard(
+                                user: user,
+                                onTapQR: {
+                                    selectedUserForQR = user
+                                    showQRCodeSheet = true
+                                },
+                                onDelete: {
+                                    deleteUser(user)
+                                },
+                                onSetDefault: {
+                                    setDefaultUser(user)
+                                },
+                                canDelete: parkrunInfoList.count > 1
+                            )
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                        }
+                    }
+                    .listStyle(PlainListStyle())
+                }
+            }
+            .navigationTitle("Family & Friends")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    HStack {
+                        if !parkrunInfoList.isEmpty {
+                            Button(action: {
+                                showUserSelection = true
+                            }) {
+                                Image(systemName: "person.2.circle")
+                                    .foregroundColor(.adaptiveParkrunGreen)
+                            }
+                        }
+                        
+                        Button(action: {
+                            showAddUser = true
+                        }) {
+                            Image(systemName: "plus.circle")
+                                .foregroundColor(.adaptiveParkrunGreen)
+                        }
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showAddUser) {
+            AddUserView(isPresented: $showAddUser) { parkrunID in
+                addNewUser(parkrunID: parkrunID)
+            }
+        }
+        .sheet(isPresented: $showUserSelection) {
+            UserSelectionView(
+                users: availableUsers,
+                currentUser: availableUsers.first(where: { $0.isDefault }),
+                isPresented: $showUserSelection,
+                onUserSelected: { user in
+                    // Just close the sheet, no switching needed in Family view
+                },
+                onDeleteUser: { user in
+                    deleteUser(user)
+                },
+                onSetDefault: { user in
+                    setDefaultUser(user)
+                }
+            )
+        }
+        .sheet(isPresented: $showQRCodeSheet) {
+            if let user = selectedUserForQR {
+                FamilyQRCodeView(user: user, isPresented: $showQRCodeSheet)
+            }
+        }
+    }
+    
+    // MARK: - Functions
+    
+    private func addNewUser(parkrunID: String) {
+        // Create new user (not default by default - only first user is automatically default)
+        let isFirstUser = parkrunInfoList.isEmpty
+        
+        let newUser = ParkrunInfo(
+            parkrunID: parkrunID,
+            name: "", // Will be filled when user saves
+            homeParkrun: "",
+            country: Country.unitedKingdom.rawValue,
+            isDefault: isFirstUser // Only first user is default automatically
+        )
+        
+        modelContext.insert(newUser)
+        
+        do {
+            try modelContext.save()
+            
+            // Fetch data for the new user in background
+            fetchParkrunnerName(for: newUser)
+            
+            print("Added new user with ID: \(parkrunID)")
+        } catch {
+            print("Failed to add new user: \(error)")
+        }
+    }
+    
+    private func deleteUser(_ user: ParkrunInfo) {
+        // Don't allow deleting the last user
+        guard parkrunInfoList.count > 1 else {
+            print("Cannot delete the last user")
+            return
+        }
+        
+        let wasDefault = user.isDefault
+        
+        // Cancel notifications for this user
+        notificationManager.cancelResultNotifications(for: user.parkrunID)
+        
+        // Delete the user
+        modelContext.delete(user)
+        
+        do {
+            try modelContext.save()
+            
+            // If the deleted user was the default, make the first remaining user default
+            if wasDefault, let firstUser = parkrunInfoList.first {
+                firstUser.isDefault = true
+                try modelContext.save()
+            }
+            
+            print("Deleted user: \(user.displayName)")
+        } catch {
+            print("Failed to delete user: \(error)")
+        }
+    }
+    
+    private func setDefaultUser(_ user: ParkrunInfo) {
+        // Remove default flag from all users
+        for parkrunUser in parkrunInfoList {
+            parkrunUser.isDefault = false
+        }
+        
+        // Set the chosen user as default
+        user.isDefault = true
+        
+        // Save changes
+        do {
+            try modelContext.save()
+            print("Set default user: \(user.displayName)")
+        } catch {
+            print("Failed to set default user: \(error)")
+        }
+    }
+    
+    private func fetchParkrunnerName(for user: ParkrunInfo) {
+        // Extract numeric part from ID (remove 'A' prefix)
+        let numericId = String(user.parkrunID.dropFirst())
+        
+        let urlString = "https://www.parkrun.org.uk/parkrunner/\(numericId)/"
+        guard let url = URL(string: urlString) else { return }
+        
+        // Create request with proper headers to avoid 403
+        var request = URLRequest(url: url)
+        request.setValue("Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1", forHTTPHeaderField: "User-Agent")
+        request.setValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")
+        request.setValue("en-US,en;q=0.5", forHTTPHeaderField: "Accept-Language")
+        request.setValue("gzip, deflate, br", forHTTPHeaderField: "Accept-Encoding")
+        request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                print("Network error for \(user.parkrunID): \(error.localizedDescription)")
+                return
+            }
+            
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                print("HTTP Error for \(user.parkrunID): \(httpResponse.statusCode)")
+                return
+            }
+            
+            guard let data = data,
+                  let htmlString = String(data: data, encoding: .utf8) else {
+                print("Failed to decode HTML data for \(user.parkrunID)")
+                return
+            }
+            
+            print("Successfully fetched HTML for ID: \(user.parkrunID)")
+            
+            // Parse the HTML to extract all information
+            let extractedData = extractParkrunnerDataFromHTML(htmlString)
+            
+            DispatchQueue.main.async {
+                // Update user data
+                if let name = extractedData.name {
+                    user.name = name
+                }
+                if let totalRuns = extractedData.totalRuns {
+                    user.totalParkruns = totalRuns
+                }
+                if let lastDate = extractedData.lastDate {
+                    user.lastParkrunDate = lastDate
+                }
+                if let lastTime = extractedData.lastTime {
+                    user.lastParkrunTime = lastTime
+                }
+                if let lastEvent = extractedData.lastEvent {
+                    user.lastParkrunEvent = lastEvent
+                }
+                if let lastEventURL = extractedData.lastEventURL {
+                    user.lastParkrunEventURL = lastEventURL
+                }
+                
+                // Update display name
+                user.updateDisplayName()
+                
+                // Save the updated data
+                do {
+                    try self.modelContext.save()
+                    print("Updated data for user: \(user.parkrunID)")
+                } catch {
+                    print("Failed to save updated data for user \(user.parkrunID): \(error)")
+                }
+            }
+        }.resume()
+    }
+    
+    private func extractParkrunnerDataFromHTML(_ html: String) -> (name: String?, totalRuns: String?, lastDate: String?, lastTime: String?, lastEvent: String?, lastEventURL: String?) {
+        var name: String?
+        var totalRuns: String?
+        var lastDate: String?
+        var lastTime: String?
+        var lastEvent: String?
+        var lastEventURL: String?
+        
+        // Extract runner name from h2 tag
+        if let nameRegex = try? NSRegularExpression(pattern: #"<h2>([^<]+?)\s*<span[^>]*title="parkrun ID"[^>]*>"#, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            let nameMatches = nameRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = nameMatches.first, let nameRange = Range(match.range(at: 1), in: html) {
+                name = String(html[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        
+        // Extract total parkruns
+        if let totalRegex = try? NSRegularExpression(pattern: #"(\d+)\s+parkruns?\s+total"#, options: [.caseInsensitive]) {
+            let totalMatches = totalRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = totalMatches.first, let totalRange = Range(match.range(at: 1), in: html) {
+                totalRuns = String(html[totalRange])
+            }
+        }
+        
+        // Look for event name in first <td><a> combination  
+        if let eventRegex = try? NSRegularExpression(pattern: #"<td><a[^>]*>([^<]+parkrun[^<]*)</a></td>"#, options: [.caseInsensitive]) {
+            let eventMatches = eventRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = eventMatches.first, let eventRange = Range(match.range(at: 1), in: html) {
+                lastEvent = String(html[eventRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        
+        // Look for date pattern DD/MM/YYYY
+        if let dateRegex = try? NSRegularExpression(pattern: #"(\d{2}/\d{2}/\d{4})"#, options: []) {
+            let dateMatches = dateRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = dateMatches.first, let dateRange = Range(match.range(at: 1), in: html) {
+                lastDate = String(html[dateRange])
+            }
+        }
+        
+        // Look for time pattern MM:SS in table
+        if let timeRegex = try? NSRegularExpression(pattern: #"<td>(\d{2}:\d{2})</td>"#, options: []) {
+            let timeMatches = timeRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = timeMatches.first, let timeRange = Range(match.range(at: 1), in: html) {
+                lastTime = String(html[timeRange])
+            }
+        }
+        
+        // Look for event results URL
+        if let eventURLRegex = try? NSRegularExpression(pattern: #"<td><a href="(https://www\.parkrun\.(?:org\.uk|com|us|au|org\.nz|co\.za|it|se|dk|pl|ie|ca|fi|fr|sg|de|no|ru|my)/[^/]+/results/\d+/)"[^>]*>\d{2}/\d{2}/\d{4}</a></td>"#, options: [.caseInsensitive]) {
+            let urlMatches = eventURLRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = urlMatches.first, let urlRange = Range(match.range(at: 1), in: html) {
+                lastEventURL = String(html[urlRange])
+            }
+        }
+        
+        return (name: name, totalRuns: totalRuns, lastDate: lastDate, lastTime: lastTime, lastEvent: lastEvent, lastEventURL: lastEventURL)
+    }
+}
+
+// MARK: - Family User Card
+
+struct FamilyUserCard: View {
+    let user: ParkrunInfo
+    let onTapQR: () -> Void
+    let onDelete: () -> Void
+    let onSetDefault: () -> Void
+    let canDelete: Bool
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            // Name row - spans full width
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text(user.name.isEmpty ? user.parkrunID : user.name)
+                            .font(.body)
+                            .fontWeight(user.isDefault ? .semibold : .medium)
+                            .foregroundColor(.primary)
+                        
+                        if user.isDefault {
+                            Image(systemName: "star.fill")
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                        }
+                        
+                        Spacer()
+                    }
+                    
+                    HStack {
+                        if !user.name.isEmpty {
+                            Text(user.parkrunID)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        if let totalRuns = user.totalParkruns, !totalRuns.isEmpty {
+                            if !user.name.isEmpty {
+                                Text("•")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Text("\(totalRuns) runs")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        Spacer()
+                    }
+                }
+                
+                // QR button
+                Button(action: onTapQR) {
+                    Image(systemName: "qrcode")
+                        .font(.title2)
+                        .foregroundColor(.adaptiveParkrunGreen)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            
+            // Data row - event, date, time
+            if user.lastParkrunEvent != nil || user.lastParkrunDate != nil || user.lastParkrunTime != nil {
+                HStack {
+                    // Last Event
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Last Event")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fontWeight(.medium)
+                        
+                        if let lastEvent = user.lastParkrunEvent, !lastEvent.isEmpty {
+                            Text(lastEvent)
+                                .font(.caption)
+                                .foregroundColor(.primary)
+                                .lineLimit(2)
+                        } else {
+                            Text("—")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    
+                    // Date
+                    VStack(alignment: .center, spacing: 2) {
+                        Text("Date")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fontWeight(.medium)
+                        
+                        if let lastDate = user.lastParkrunDate, !lastDate.isEmpty {
+                            Text(lastDate)
+                                .font(.caption)
+                                .foregroundColor(.primary)
+                        } else {
+                            Text("—")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .frame(width: 80, alignment: .center)
+                    
+                    // Time
+                    VStack(alignment: .center, spacing: 2) {
+                        Text("Time")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fontWeight(.medium)
+                        
+                        if let lastTime = user.lastParkrunTime, !lastTime.isEmpty {
+                            Text(lastTime)
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundColor(.adaptiveParkrunGreen)
+                        } else {
+                            Text("—")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .frame(width: 60, alignment: .center)
+                }
+            }
+        }
+        .padding()
+        .background(Color.adaptiveCardBackground)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if canDelete {
+                Button(role: .destructive, action: onDelete) {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+            
+            if !user.isDefault {
+                Button(action: onSetDefault) {
+                    Label("Set Default", systemImage: "star")
+                }
+                .tint(.orange)
+            }
+        }
+    }
+}
+
+// MARK: - Family QR Code View
+
+struct FamilyQRCodeView: View {
+    let user: ParkrunInfo
+    @Binding var isPresented: Bool
+    @State private var selectedCodeType: Int = 0 // 0 = QR Code, 1 = Barcode
+    
+    private let context = CIContext()
+    private let qrCodeFilter = CIFilter.qrCodeGenerator()
+    private let barcodeFilter = CIFilter.code128BarcodeGenerator()
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                // User info
+                VStack(spacing: 8) {
+                    Text(user.name.isEmpty ? user.parkrunID : user.name)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.adaptiveParkrunGreen)
+                    
+                    if !user.name.isEmpty {
+                        Text(user.parkrunID)
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    if let totalRuns = user.totalParkruns, !totalRuns.isEmpty {
+                        Text("\(totalRuns) total parkruns")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding()
+                .background(Color.adaptiveCardBackground)
+                .cornerRadius(12)
+                
+                // Code type picker
+                Picker("Code Type", selection: $selectedCodeType) {
+                    Text("QR Code").tag(0)
+                    Text("Barcode").tag(1)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .padding(.horizontal)
+                
+                // QR Code or Barcode
+                VStack {
+                    if selectedCodeType == 0 {
+                        if let qrImage = generateQRCode(from: user.parkrunID) {
+                            Image(uiImage: qrImage)
+                                .resizable()
+                                .interpolation(.none)
+                                .scaledToFit()
+                                .frame(width: 250, height: 250)
+                                .background(Color.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 16))
+                                .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
+                        }
+                    } else {
+                        if let barcodeImage = generateBarcode(from: user.parkrunID) {
+                            Image(uiImage: barcodeImage)
+                                .resizable()
+                                .interpolation(.none)
+                                .scaledToFit()
+                                .frame(width: 300, height: 100)
+                                .background(Color.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 16))
+                                .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
+                        }
+                    }
+                }
+                .padding()
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("QR Code")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        isPresented = false
+                    }
+                }
+            }
+        }
+    }
+    
+    // MARK: - QR & Barcode Generation
+    private func generateQRCode(from string: String) -> UIImage? {
+        guard !string.isEmpty else { return nil }
+        qrCodeFilter.message = Data(string.utf8)
+        guard let ciImage = qrCodeFilter.outputImage else { return nil }
+        return convertToUIImage(from: ciImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10)))
+    }
+
+    private func generateBarcode(from string: String) -> UIImage? {
+        guard !string.isEmpty else { return nil }
+        barcodeFilter.message = Data(string.utf8)
+        guard let ciImage = barcodeFilter.outputImage else { return nil }
+        return convertToUIImage(from: ciImage.transformed(by: CGAffineTransform(scaleX: 2, y: 2)))
+    }
+
+    private func convertToUIImage(from ciImage: CIImage) -> UIImage? {
+        guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+#Preview {
+    do {
+        let previewContainer = try ModelContainer(for: ParkrunInfo.self, configurations: ModelConfiguration())
+        let context = previewContainer.mainContext
+        
+        // Insert sample data for preview
+        let user1 = ParkrunInfo(parkrunID: "A12345", name: "John Doe", homeParkrun: "Southampton", country: Country.unitedKingdom.rawValue, totalParkruns: "25", lastParkrunDate: "14/06/2025", lastParkrunTime: "22:30", lastParkrunEvent: "Southampton parkrun", isDefault: true)
+        let user2 = ParkrunInfo(parkrunID: "A67890", name: "Jane Smith", homeParkrun: "Portsmouth", country: Country.unitedKingdom.rawValue, totalParkruns: "15", lastParkrunDate: "07/06/2025", lastParkrunTime: "25:45", lastParkrunEvent: "Portsmouth parkrun")
+        
+        context.insert(user1)
+        context.insert(user2)
+        
+        return FamilyTabView()
+            .modelContainer(previewContainer)
+            .environmentObject(NotificationManager.shared)
+    } catch {
+        return Text("Failed to create preview: \(error)")
+    }
+}

--- a/PR Bar Code/Views/FamilyTabView.swift
+++ b/PR Bar Code/Views/FamilyTabView.swift
@@ -135,16 +135,7 @@ struct FamilyTabView: View {
             }
         }
         .onAppear {
-            // Debug: Print current user states when view appears
-            print("DEBUG - FamilyTabView onAppear:")
-            for user in parkrunInfoList {
-                print("DEBUG - User: \(user.displayName) isDefault=\(user.isDefault)")
-                print("DEBUG -   parkrunID: \(user.parkrunID)")
-                print("DEBUG -   name: '\(user.name)'")
-                print("DEBUG -   displayName: '\(user.displayName)'")
-            }
-            
-            // Data correction: Fix corrupted names
+            // Data correction: Fix corrupted names (one-time fix)
             fixCorruptedUserNames()
         }
     }
@@ -242,12 +233,6 @@ struct FamilyTabView: View {
     }
     
     private func setDefaultUser(_ user: ParkrunInfo) {
-        // Debug: Print current state
-        print("DEBUG - setDefaultUser called for: \(user.displayName)")
-        for parkrunUser in parkrunInfoList {
-            print("DEBUG - Before change: \(parkrunUser.displayName) isDefault=\(parkrunUser.isDefault)")
-        }
-        
         // Remove default flag from all users
         for parkrunUser in parkrunInfoList {
             parkrunUser.isDefault = false
@@ -260,11 +245,6 @@ struct FamilyTabView: View {
         do {
             try modelContext.save()
             print("Set default user: \(user.displayName)")
-            
-            // Debug: Print state after save
-            for parkrunUser in parkrunInfoList {
-                print("DEBUG - After change: \(parkrunUser.displayName) isDefault=\(parkrunUser.isDefault)")
-            }
         } catch {
             print("Failed to set default user: \(error)")
         }

--- a/PR Bar Code/Views/MainTabView.swift
+++ b/PR Bar Code/Views/MainTabView.swift
@@ -1,0 +1,70 @@
+//
+//  MainTabView.swift
+//  PR Bar Code
+//
+//  Created by Claude Code on 15/06/2025.
+//
+
+import SwiftUI
+import SwiftData
+
+struct MainTabView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var parkrunInfoList: [ParkrunInfo]
+    @EnvironmentObject var notificationManager: NotificationManager
+    @State private var selectedTab = 0
+    
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            // Me Tab - Default user only
+            MeTabView()
+                .tabItem {
+                    Image(systemName: "person.circle")
+                    Text("Me")
+                }
+                .tag(0)
+            
+            // Family & Friends Tab - All users with results table
+            FamilyTabView()
+                .tabItem {
+                    Image(systemName: "person.2.circle")
+                    Text("Family")
+                }
+                .tag(1)
+            
+            // Events Tab - Placeholder for future features
+            EventsTabView()
+                .tabItem {
+                    Image(systemName: "calendar.circle")
+                    Text("Events")
+                }
+                .tag(2)
+            
+            // Settings Tab - Notifications, dark mode, etc.
+            SettingsTabView()
+                .tabItem {
+                    Image(systemName: "gearshape.circle")
+                    Text("Settings")
+                }
+                .tag(3)
+        }
+        .accentColor(.adaptiveParkrunGreen)
+    }
+}
+
+#Preview {
+    do {
+        let previewContainer = try ModelContainer(for: ParkrunInfo.self, configurations: ModelConfiguration())
+        let context = previewContainer.mainContext
+        
+        // Insert sample data for preview
+        let previewParkrunInfo = ParkrunInfo(parkrunID: "A12345", name: "John Doe", homeParkrun: "Southampton Parkrun", country: Country.unitedKingdom.rawValue, isDefault: true)
+        context.insert(previewParkrunInfo)
+        
+        return MainTabView()
+            .modelContainer(previewContainer)
+            .environmentObject(NotificationManager.shared)
+    } catch {
+        return Text("Failed to create preview: \(error)")
+    }
+}

--- a/PR Bar Code/Views/MeTabView.swift
+++ b/PR Bar Code/Views/MeTabView.swift
@@ -1,0 +1,1108 @@
+//
+//  MeTabView.swift
+//  PR Bar Code
+//
+//  Created by Claude Code on 15/06/2025.
+//
+
+import SwiftUI
+import SwiftData
+import CoreImage.CIFilterBuiltins
+import WatchConnectivity
+
+struct MeTabView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var parkrunInfoList: [ParkrunInfo]
+    @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject var notificationManager: NotificationManager
+    
+    @State private var inputText: String = ""
+    @State private var name: String = ""
+    @State private var homeParkrun: String = ""
+    @State private var selectedCountryCode: Int = Country.unitedKingdom.rawValue
+    @State private var isEditing: Bool = false
+    @State private var showAlert: Bool = false
+    @State private var alertMessage: String = ""
+    @State private var selectedCodeType: Int = 0 // 0 = QR Code, 1 = Barcode
+    @State private var isLoadingName: Bool = false
+    @State private var showConfirmationDialog: Bool = false
+    @State private var totalParkruns: String = ""
+    @State private var lastParkrunDate: String = ""
+    @State private var lastParkrunTime: String = ""
+    @State private var lastParkrunEvent: String = ""
+    @State private var lastParkrunEventURL: String = ""
+    @State private var watchSyncStatus: WatchSyncStatus = .idle
+    @State private var showOnboarding: Bool = false
+    
+    private let context = CIContext()
+    private let qrCodeFilter = CIFilter.qrCodeGenerator()
+    private let barcodeFilter = CIFilter.code128BarcodeGenerator()
+    
+    // Get default user only
+    private var defaultUser: ParkrunInfo? {
+        if let defaultUser = parkrunInfoList.first(where: { $0.isDefault }) {
+            return defaultUser
+        }
+        return parkrunInfoList.first
+    }
+    
+    private var confirmationMessage: String {
+        var message = "Please confirm your details:\n\nParkrun ID: \(inputText)"
+        
+        if !name.isEmpty {
+            message += "\nName: \(name)"
+        }
+        
+        if !totalParkruns.isEmpty {
+            message += "\nTotal Parkruns: \(totalParkruns)"
+        }
+        
+        if !lastParkrunDate.isEmpty && !lastParkrunTime.isEmpty && !lastParkrunEvent.isEmpty {
+            message += "\nLast Parkrun: \(lastParkrunEvent)"
+            message += "\nDate: \(lastParkrunDate), Time: \(lastParkrunTime)"
+        }
+        
+        return message
+    }
+    
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 20) {
+                    
+                    if isEditing || defaultUser == nil {
+                        // Personal Information Card
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Personal Information")
+                                .font(.title2)
+                                .fontWeight(.bold)
+                                .foregroundColor(.adaptiveParkrunGreen)
+                            
+                            personalInfoSection
+                        }
+                        .cardStyle()
+                        .transition(AnimationConstants.cardTransition)
+                        
+                        // QR Code Card
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Your Code")
+                                .font(.title2)
+                                .fontWeight(.bold)
+                                .foregroundColor(.adaptiveParkrunGreen)
+                            
+                            qrCodeAndBarcodeSection
+                        }
+                        .cardStyle()
+                        .transition(AnimationConstants.cardTransition)
+                        
+                        // Send to Watch Button
+                        sendToWatchSection
+                            .cardStyle()
+                            .transition(AnimationConstants.cardTransition)
+                        
+                        // Watch Sync Card
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Watch Sync")
+                                .font(.title2)
+                                .fontWeight(.bold)
+                                .foregroundColor(.adaptiveParkrunGreen)
+                            
+                            watchSyncIndicator
+                        }
+                        .cardStyle()
+                        .transition(AnimationConstants.cardTransition)
+                        
+                    } else {
+                        // Display Default User Data
+                        VStack(spacing: 20) {
+                            // Personal Information Card
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("My Information")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.adaptiveParkrunGreen)
+                                
+                                personalInfoSection
+                            }
+                            .cardStyle()
+                            
+                            // QR Code Card
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("My QR Code")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.adaptiveParkrunGreen)
+                                
+                                qrCodeAndBarcodeSection
+                            }
+                            .cardStyle()
+                            
+                            // Send to Watch Button
+                            sendToWatchSection
+                                .cardStyle()
+                            
+                            // Watch Sync Card
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Watch Sync")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.adaptiveParkrunGreen)
+                                
+                                watchSyncIndicator
+                            }
+                            .cardStyle()
+                        }
+                        .transition(AnimationConstants.slideTransition)
+                    }
+                }
+                .padding()
+                .animation(AnimationConstants.springAnimation, value: isEditing)
+            }
+            .navigationTitle("Me")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if isEditing {
+                        Button("Cancel") {
+                            withAnimation(AnimationConstants.springAnimation) {
+                                cancelEdit()
+                            }
+                        }
+                    }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if isEditing {
+                        Button("Save") {
+                            withAnimation(AnimationConstants.springAnimation) {
+                                // Refresh user details and show confirmation dialog without saving
+                                fetchParkrunnerName(id: inputText) {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                                        self.showConfirmationDialog = true
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        Button("Edit") {
+                            withAnimation(AnimationConstants.springAnimation) {
+                                startEdit()
+                            }
+                        }
+                    }
+                }
+            }
+            .background(Color(.systemGroupedBackground))
+        }
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text("Invalid Input"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
+        }
+        .confirmationDialog("Confirm Details", isPresented: $showConfirmationDialog, titleVisibility: .visible) {
+            Button("Save") {
+                saveParkrunInfo()
+            }
+            Button("Cancel", role: .cancel) {
+                // Revert Parkrun details back to original
+                loadInitialData()
+            }
+        } message: {
+            Text(confirmationMessage)
+        }
+        .onAppear {
+            loadInitialData()
+            WatchSessionManager.shared.startSession()
+            checkForOnboarding()
+            refreshEventDataIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            // Refresh data when app comes back to foreground
+            refreshEventDataIfNeeded()
+        }
+        .sheet(isPresented: $showOnboarding) {
+            OnboardingView(isPresented: $showOnboarding)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SetParkrunID"))) { notification in
+            if let parkrunID = notification.object as? String {
+                inputText = parkrunID
+                // Clear existing data and trigger API lookup
+                name = ""
+                totalParkruns = ""
+                lastParkrunDate = ""
+                lastParkrunTime = ""
+                lastParkrunEvent = ""
+                lastParkrunEventURL = ""
+                
+                // Trigger edit mode to show the new ID
+                isEditing = true
+                
+                // Fetch data for the ID
+                fetchParkrunnerName(id: parkrunID)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SetParkrunIDWithConfirmation"))) { notification in
+            if let parkrunID = notification.object as? String {
+                inputText = parkrunID
+                // Clear existing data and trigger API lookup
+                name = ""
+                totalParkruns = ""
+                lastParkrunDate = ""
+                lastParkrunTime = ""
+                lastParkrunEvent = ""
+                lastParkrunEventURL = ""
+                
+                // Trigger edit mode to show the new ID
+                isEditing = true
+                
+                // Fetch data for the ID and show confirmation dialog when done
+                fetchParkrunnerName(id: parkrunID) {
+                    // Show confirmation dialog after API call completes
+                    print("Onboarding: API lookup completed, showing confirmation dialog")
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                        self.showConfirmationDialog = true
+                    }
+                }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RefreshParkrunData"))) { notification in
+            if let parkrunID = notification.object as? String, parkrunID == inputText {
+                // Refresh data when notification is tapped
+                print("Refreshing parkrun data from notification tap")
+                refreshEventDataIfNeeded()
+            }
+        }
+    }
+    
+    // MARK: - View Components (reuse from original QRCodeView)
+    // [Copy the relevant view components from QRCodeView.swift]
+    
+    // MARK: - Personal Info Section
+    private var personalInfoSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if isEditing {
+                VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Parkrun ID")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        
+                        HStack {
+                            TextField("Parkrun ID (e.g., A12345)", text: $inputText)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.asciiCapable)
+                            
+                            if isLoadingName {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                            } else if inputText.range(of: #"^A\d+$"#, options: .regularExpression) != nil {
+                                if !name.isEmpty {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundColor(.green)
+                                } else {
+                                    Image(systemName: "magnifyingglass.circle.fill")
+                                        .foregroundColor(.blue)
+                                }
+                            } else if !inputText.isEmpty {
+                                Image(systemName: "exclamationmark.circle.fill")
+                                    .foregroundColor(.red)
+                            }
+                        }
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Name")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(name.isEmpty ? "Auto-filled from Parkrun ID" : name)
+                            .font(.body)
+                            .foregroundColor(name.isEmpty ? .secondary : .primary)
+                            .padding(6)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color(.tertiarySystemBackground))
+                            .cornerRadius(6)
+                    }
+                    
+                    // Show total parkruns if available
+                    if !totalParkruns.isEmpty {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Total Parkruns")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Text(totalParkruns)
+                                .font(.body)
+                                .padding(6)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color(.tertiarySystemBackground))
+                                .cornerRadius(6)
+                        }
+                    }
+                    
+                    // Show last parkrun table if data is available
+                    if !lastParkrunDate.isEmpty && !lastParkrunTime.isEmpty && !lastParkrunEvent.isEmpty {
+                        lastParkrunSection
+                    }
+                }
+                .transition(AnimationConstants.fadeTransition)
+            } else {
+                // Read-only display
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Parkrun ID")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        
+                        Button(action: {
+                            openParkrunProfile()
+                        }) {
+                            HStack {
+                                Text(inputText.isEmpty ? "Not set" : inputText)
+                                    .font(.body)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.blue)
+                                
+                                if !inputText.isEmpty {
+                                    Image(systemName: "safari")
+                                        .font(.caption)
+                                        .foregroundColor(.blue)
+                                }
+                            }
+                            .padding(6)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color(.tertiarySystemBackground))
+                            .cornerRadius(6)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .disabled(inputText.isEmpty)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Total Parkruns")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(totalParkruns.isEmpty ? "Not set" : totalParkruns)
+                            .font(.body)
+                            .padding(6)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color(.tertiarySystemBackground))
+                            .cornerRadius(6)
+                    }
+                }
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Name")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    
+                    Button(action: {
+                        openParkrunProfile()
+                    }) {
+                        HStack {
+                            Text(name.isEmpty ? "Not set" : name)
+                                .font(.body)
+                                .foregroundColor(name.isEmpty ? .secondary : .blue)
+                            
+                            if !name.isEmpty && !inputText.isEmpty {
+                                Image(systemName: "safari")
+                                    .font(.caption)
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                        .padding(6)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(.tertiarySystemBackground))
+                        .cornerRadius(6)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .disabled(name.isEmpty || inputText.isEmpty)
+                }
+                
+                if !lastParkrunDate.isEmpty && !lastParkrunTime.isEmpty && !lastParkrunEvent.isEmpty {
+                    lastParkrunSection
+                }
+            }
+        }
+        .padding(10)
+        .background(Color.adaptiveCardBackground)
+        .cornerRadius(10)
+        .shadow(radius: 2)
+        .frame(maxWidth: .infinity)
+    }
+    
+    private var lastParkrunSection: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Last Parkrun")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            VStack(spacing: 0) {
+                // Header row
+                HStack {
+                    Text("Event")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("Date")
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                        .frame(width: 75, alignment: .center)
+                    Text("Time")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                        .frame(width: 60, alignment: .center)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color(.quaternarySystemFill))
+                
+                // Data row
+                HStack(alignment: .center) {
+                    Button(action: {
+                        openEventResults()
+                    }) {
+                        HStack {
+                            Text(lastParkrunEvent)
+                                .font(.body)
+                                .foregroundColor(.blue)
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.7)
+                                .fixedSize(horizontal: false, vertical: true)
+                            
+                            if !lastParkrunEventURL.isEmpty {
+                                Image(systemName: "safari")
+                                    .font(.caption2)
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .disabled(lastParkrunEventURL.isEmpty)
+                    
+                    Text(lastParkrunDate)
+                        .font(.caption)
+                        .frame(width: 75, alignment: .center)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                    Text(lastParkrunTime)
+                        .font(.body)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.primary)
+                        .frame(width: 60, alignment: .center)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(Color(.tertiarySystemBackground))
+            }
+            .cornerRadius(8)
+        }
+    }
+    
+    // MARK: - QR Code and Barcode Section
+    private var qrCodeAndBarcodeSection: some View {
+        VStack(spacing: 16) {
+            Picker("Code Type", selection: $selectedCodeType) {
+                Text("QR Code").tag(0)
+                Text("Barcode").tag(1)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            
+            HStack {
+                if selectedCodeType == 0 {
+                    CodeSectionView(
+                        title: "",
+                        image: generateQRCode(from: inputText),
+                        size: CGSize(width: 200, height: 200)
+                    )
+                } else {
+                    CodeSectionView(
+                        title: "",
+                        image: generateBarcode(from: inputText),
+                        size: CGSize(width: 300, height: 100)
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(10)
+        .background(Color.adaptiveCardBackground)
+        .cornerRadius(10)
+        .shadow(radius: 2)
+        .frame(maxWidth: .infinity)
+    }
+    
+    // MARK: - Watch Sync Indicator
+    private var watchSyncIndicator: some View {
+        VStack(spacing: 12) {
+            Divider()
+                .padding(.horizontal)
+            
+            VStack(spacing: 8) {
+                if WCSession.default.isReachable {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                            .font(.caption)
+                        Text("Watch Connected")
+                            .font(.caption)
+                            .foregroundColor(.green)
+                    }
+                } else {
+                    VStack(spacing: 8) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                            Text("Watch Not Connected")
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                        }
+                        
+                        Button(action: {
+                            withAnimation(AnimationConstants.springAnimation) {
+                                openWatchQRCode()
+                            }
+                        }) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "qrcode")
+                                    .font(.caption)
+                                Text("Open 5K QR Code on Watch")
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                            }
+                            .foregroundColor(.blue)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.blue.opacity(0.1))
+                            .cornerRadius(8)
+                        }
+                        .disabled(inputText.isEmpty)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 16)
+        }
+        .background(Color.adaptiveCardBackground)
+    }
+    
+    // MARK: - Send to Watch Section
+    private var sendToWatchSection: some View {
+        VStack(spacing: 12) {
+            Button(action: {
+                withAnimation(AnimationConstants.springAnimation) {
+                    sendToWatch()
+                }
+            }) {
+                HStack(spacing: 8) {
+                    if watchSyncStatus == .sending {
+                        ProgressView()
+                            .scaleEffect(0.8)
+                    } else {
+                        Image(systemName: "applewatch")
+                            .font(.title3)
+                    }
+                    
+                    Text(watchSyncStatus == .sending ? "Sending..." : "Send to Watch")
+                        .font(.headline)
+                        .fontWeight(.medium)
+                }
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(watchSyncStatus == .sending ? Color.gray : Color.adaptiveParkrunGreen)
+                .cornerRadius(12)
+            }
+            .disabled(watchSyncStatus == .sending || inputText.isEmpty)
+            .animation(AnimationConstants.springAnimation, value: watchSyncStatus)
+        }
+    }
+    
+    // MARK: - Functions
+    private func loadInitialData() {
+        print("DEBUG - MeTab loadInitialData: Found \(parkrunInfoList.count) users")
+        
+        if let savedInfo = defaultUser {
+            inputText = savedInfo.parkrunID
+            name = savedInfo.name
+            homeParkrun = savedInfo.homeParkrun
+            selectedCountryCode = savedInfo.country ?? Country.unitedKingdom.rawValue
+            totalParkruns = savedInfo.totalParkruns ?? ""
+            lastParkrunDate = savedInfo.lastParkrunDate ?? ""
+            lastParkrunTime = savedInfo.lastParkrunTime ?? ""
+            lastParkrunEvent = savedInfo.lastParkrunEvent ?? ""
+            lastParkrunEventURL = savedInfo.lastParkrunEventURL ?? ""
+            
+            print("DEBUG - MeTab loadInitialData: Loaded default user - parkrunID='\(savedInfo.parkrunID)', name='\(savedInfo.name)'")
+        } else {
+            print("DEBUG - MeTab loadInitialData: No default user found")
+        }
+    }
+    
+    private func checkForOnboarding() {
+        // Show onboarding if no default user exists
+        if defaultUser == nil {
+            showOnboarding = true
+        }
+    }
+    
+    private func refreshEventDataIfNeeded() {
+        // Only refresh if we have a valid parkrun ID and we're not currently editing
+        guard !inputText.isEmpty, 
+              inputText.range(of: #"^A\d+$"#, options: .regularExpression) != nil,
+              !isEditing,
+              !isLoadingName else {
+            print("DEBUG - MeTab refreshEventDataIfNeeded: Skipping refresh - invalid ID or currently editing")
+            return
+        }
+        
+        print("DEBUG - MeTab refreshEventDataIfNeeded: Refreshing event data for ID: \(inputText)")
+        
+        // Refresh the parkrun data in background without showing loading indicators
+        fetchParkrunnerName(id: inputText, showLoadingIndicator: false) {
+            print("DEBUG - MeTab refreshEventDataIfNeeded: Background refresh completed")
+            // Auto-save the updated data
+            DispatchQueue.main.async {
+                self.saveUpdatedDataSilently()
+            }
+        }
+    }
+    
+    private func saveUpdatedDataSilently() {
+        // Save updated data without triggering UI changes or watch sync
+        if let existingInfo = defaultUser {
+            existingInfo.name = name
+            existingInfo.totalParkruns = totalParkruns.isEmpty ? nil : totalParkruns
+            existingInfo.lastParkrunDate = lastParkrunDate.isEmpty ? nil : lastParkrunDate
+            existingInfo.lastParkrunTime = lastParkrunTime.isEmpty ? nil : lastParkrunTime
+            existingInfo.lastParkrunEvent = lastParkrunEvent.isEmpty ? nil : lastParkrunEvent
+            existingInfo.lastParkrunEventURL = lastParkrunEventURL.isEmpty ? nil : lastParkrunEventURL
+            
+            do {
+                try modelContext.save()
+                print("DEBUG - MeTab saveUpdatedDataSilently: Successfully saved refreshed data")
+            } catch {
+                print("DEBUG - MeTab saveUpdatedDataSilently: Failed to save refreshed data: \(error)")
+            }
+        }
+    }
+
+    private func saveParkrunInfo() {
+        guard !inputText.isEmpty, inputText.range(of: #"^A\d+$"#, options: .regularExpression) != nil else {
+            alertMessage = "Parkrun ID must start with 'A' followed by numbers (e.g., A12345)."
+            showAlert = true
+            return
+        }
+
+        completeSave()
+    }
+    
+    private func completeSave() {
+        if let existingInfo = defaultUser {
+            // Update existing default user
+            existingInfo.parkrunID = inputText
+            existingInfo.name = name
+            existingInfo.homeParkrun = homeParkrun
+            existingInfo.country = selectedCountryCode
+            existingInfo.totalParkruns = totalParkruns.isEmpty ? nil : totalParkruns
+            existingInfo.lastParkrunDate = lastParkrunDate.isEmpty ? nil : lastParkrunDate
+            existingInfo.lastParkrunTime = lastParkrunTime.isEmpty ? nil : lastParkrunTime
+            existingInfo.lastParkrunEvent = lastParkrunEvent.isEmpty ? nil : lastParkrunEvent
+            existingInfo.lastParkrunEventURL = lastParkrunEventURL.isEmpty ? nil : lastParkrunEventURL
+            existingInfo.updateDisplayName()
+        } else {
+            // Create new default user (first user is always default)
+            let newInfo = ParkrunInfo(
+                parkrunID: inputText, 
+                name: name, 
+                homeParkrun: homeParkrun, 
+                country: selectedCountryCode,
+                totalParkruns: totalParkruns.isEmpty ? nil : totalParkruns,
+                lastParkrunDate: lastParkrunDate.isEmpty ? nil : lastParkrunDate,
+                lastParkrunTime: lastParkrunTime.isEmpty ? nil : lastParkrunTime,
+                lastParkrunEvent: lastParkrunEvent.isEmpty ? nil : lastParkrunEvent,
+                lastParkrunEventURL: lastParkrunEventURL.isEmpty ? nil : lastParkrunEventURL,
+                isDefault: true // This is the default user
+            )
+            modelContext.insert(newInfo)
+        }
+
+        do {
+            try modelContext.save()
+            isEditing = false
+            
+            // Set up notifications for the user if enabled
+            if notificationManager.hasPermission && notificationManager.isNotificationsEnabled {
+                setupNotificationsForCurrentUser()
+            }
+            
+            // Send to watch automatically for default user
+            watchSyncStatus = .sending
+            WatchSessionManager.shared.sendParkrunID(inputText, userName: name) { success in
+                DispatchQueue.main.async {
+                    self.watchSyncStatus = success ? .success : .failed
+                    
+                    // Reset status after 3 seconds
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        self.watchSyncStatus = .idle
+                    }
+                }
+            }
+        } catch {
+            alertMessage = "Failed to save data. Please try again."
+            showAlert = true
+        }
+    }
+
+    private func startEdit() {
+        isEditing = true
+    }
+
+    private func cancelEdit() {
+        isEditing = false
+        loadInitialData()
+    }
+    
+    private func sendToWatch() {
+        guard !inputText.isEmpty else {
+            alertMessage = "No Parkrun ID available to send."
+            showAlert = true
+            return
+        }
+        
+        // Send to watch with status tracking
+        watchSyncStatus = .sending
+        WatchSessionManager.shared.sendParkrunID(inputText, userName: name) { success in
+            DispatchQueue.main.async {
+                self.watchSyncStatus = success ? .success : .failed
+                
+                // Reset status after 3 seconds
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    self.watchSyncStatus = .idle
+                }
+            }
+        }
+    }
+    
+    private func setupNotificationsForCurrentUser() {
+        guard notificationManager.hasPermission, !inputText.isEmpty else { return }
+        
+        // Schedule result check notifications if we have parkrun data
+        if !lastParkrunDate.isEmpty {
+            notificationManager.scheduleBackgroundResultCheck(for: inputText, lastKnownDate: lastParkrunDate)
+        }
+        
+        print("Notifications set up for user: \(name.isEmpty ? inputText : name)")
+    }
+    
+    private func openEventResults() {
+        print("DEBUG - openEventResults called with URL: '\(lastParkrunEventURL)'")
+        guard !lastParkrunEventURL.isEmpty else {
+            print("DEBUG - openEventResults failed: URL is empty")
+            alertMessage = "No event results URL available."
+            showAlert = true
+            return
+        }
+        
+        guard let url = URL(string: lastParkrunEventURL) else {
+            alertMessage = "Invalid event results URL."
+            showAlert = true
+            return
+        }
+        
+        #if os(iOS)
+        UIApplication.shared.open(url) { success in
+            if !success {
+                DispatchQueue.main.async {
+                    self.alertMessage = "Unable to open event results page."
+                    self.showAlert = true
+                }
+            }
+        }
+        #endif
+    }
+    
+    private func openParkrunProfile() {
+        guard !inputText.isEmpty, inputText.range(of: #"^A\d+$"#, options: .regularExpression) != nil else {
+            alertMessage = "Invalid Parkrun ID. Cannot open profile page."
+            showAlert = true
+            return
+        }
+        
+        // Extract numeric part from ID (remove 'A' prefix)
+        let numericId = String(inputText.dropFirst())
+        let profileURL = "https://www.parkrun.org.uk/parkrunner/\(numericId)/all/"
+        
+        guard let url = URL(string: profileURL) else {
+            alertMessage = "Unable to create profile URL."
+            showAlert = true
+            return
+        }
+        
+        #if os(iOS)
+        UIApplication.shared.open(url) { success in
+            if !success {
+                DispatchQueue.main.async {
+                    self.alertMessage = "Unable to open parkrun profile page."
+                    self.showAlert = true
+                }
+            }
+        }
+        #endif
+    }
+    
+    private func openWatchQRCode() {
+        guard !inputText.isEmpty else {
+            alertMessage = "No Parkrun ID available to display."
+            showAlert = true
+            return
+        }
+        
+        // Try to open the watch app directly to show QR code
+        #if os(iOS)
+        let watchAppURL = URL(string: "watch://")
+        if let url = watchAppURL, UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url) { success in
+                if success {
+                    print("Successfully opened watch app")
+                    // Send the parkrun ID with a special flag to show QR immediately
+                    WatchSessionManager.shared.sendParkrunIDForQRDisplay(inputText, userName: name)
+                } else {
+                    print("Failed to open watch app")
+                    DispatchQueue.main.async {
+                        self.alertMessage = "Unable to open watch app. Make sure your Apple Watch is nearby and the app is installed."
+                        self.showAlert = true
+                    }
+                }
+            }
+        } else {
+            // Fallback: try to send data and hope watch app opens
+            WatchSessionManager.shared.sendParkrunIDForQRDisplay(inputText, userName: name)
+            alertMessage = "QR code sent to watch. Please open the Parkrun app on your Apple Watch."
+            showAlert = true
+        }
+        #endif
+    }
+    
+    // MARK: - Parkrun API Functions
+    private func fetchParkrunnerName(id: String, showLoadingIndicator: Bool = true, completion: (() -> Void)? = nil) {
+        // Extract numeric part from ID (remove 'A' prefix)
+        let numericId = String(id.dropFirst())
+        
+        if showLoadingIndicator {
+            isLoadingName = true
+        }
+        
+        let urlString = "https://www.parkrun.org.uk/parkrunner/\(numericId)/"
+        guard let url = URL(string: urlString) else {
+            if showLoadingIndicator {
+                isLoadingName = false
+            }
+            completion?()
+            return
+        }
+        
+        // Create request with proper headers to avoid 403
+        var request = URLRequest(url: url)
+        request.setValue("Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1", forHTTPHeaderField: "User-Agent")
+        request.setValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")
+        request.setValue("en-US,en;q=0.5", forHTTPHeaderField: "Accept-Language")
+        request.setValue("gzip, deflate, br", forHTTPHeaderField: "Accept-Encoding")
+        request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            DispatchQueue.main.async {
+                if showLoadingIndicator {
+                    self.isLoadingName = false
+                }
+            }
+            
+            if let error = error {
+                print("Network error: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    completion?()
+                }
+                return
+            }
+            
+            if let httpResponse = response as? HTTPURLResponse {
+                print("HTTP Status Code: \(httpResponse.statusCode)")
+                if httpResponse.statusCode != 200 {
+                    print("HTTP Error: \(httpResponse.statusCode)")
+                    DispatchQueue.main.async {
+                        completion?()
+                    }
+                    return
+                }
+            }
+            
+            guard let data = data else {
+                print("No data received")
+                DispatchQueue.main.async {
+                    completion?()
+                }
+                return
+            }
+            
+            guard let htmlString = String(data: data, encoding: .utf8) else {
+                print("Failed to decode HTML data")
+                DispatchQueue.main.async {
+                    completion?()
+                }
+                return
+            }
+            
+            print("Successfully fetched HTML for ID: \(id)")
+            
+            // Parse the HTML to extract all information
+            let extractedData = self.extractParkrunnerDataFromHTML(htmlString)
+            
+            DispatchQueue.main.async {
+                if let name = extractedData.name {
+                    self.name = name
+                    print("Successfully extracted name: \(name)")
+                }
+                if let totalRuns = extractedData.totalRuns {
+                    self.totalParkruns = totalRuns
+                    print("Total parkruns: \(totalRuns)")
+                }
+                if let lastDate = extractedData.lastDate {
+                    self.lastParkrunDate = lastDate
+                    print("Last parkrun date: \(lastDate)")
+                }
+                if let lastTime = extractedData.lastTime {
+                    self.lastParkrunTime = lastTime
+                    print("Last parkrun time: \(lastTime)")
+                }
+                if let lastEvent = extractedData.lastEvent {
+                    self.lastParkrunEvent = lastEvent
+                    print("Last parkrun event: \(lastEvent)")
+                }
+                if let lastEventURL = extractedData.lastEventURL {
+                    self.lastParkrunEventURL = lastEventURL
+                    print("Last parkrun event URL: \(lastEventURL)")
+                    print("DEBUG - lastParkrunEventURL is now set to: '\(self.lastParkrunEventURL)'")
+                } else {
+                    print("DEBUG - No lastEventURL found in extracted data, lastParkrunEventURL remains: '\(self.lastParkrunEventURL)'")
+                }
+                completion?()
+            }
+        }.resume()
+    }
+    
+    private func extractParkrunnerDataFromHTML(_ html: String) -> (name: String?, totalRuns: String?, lastDate: String?, lastTime: String?, lastEvent: String?, lastEventURL: String?) {
+        var name: String?
+        var totalRuns: String?
+        var lastDate: String?
+        var lastTime: String?
+        var lastEvent: String?
+        var lastEventURL: String?
+        
+        print("DEBUG - Starting HTML parsing, HTML length: \(html.count)")
+        
+        // Extract runner name from h2 tag: <h2>Matt GARDNER <span style="font-weight: normal;" title="parkrun ID">(A79156)</span></h2>
+        if let nameRegex = try? NSRegularExpression(pattern: #"<h2>([^<]+?)\s*<span[^>]*title="parkrun ID"[^>]*>"#, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            let nameMatches = nameRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = nameMatches.first, let nameRange = Range(match.range(at: 1), in: html) {
+                name = String(html[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+                print("DEBUG - Extracted name: '\(name ?? "nil")'")
+            } else {
+                print("DEBUG - No name match found")
+            }
+        } else {
+            print("DEBUG - Failed to create name regex")
+        }
+        
+        // Extract total parkruns from h3 tag: <h3>279 parkruns total</h3>
+        // Try simpler pattern first
+        if let totalRegex = try? NSRegularExpression(pattern: #"(\d+)\s+parkruns?\s+total"#, options: [.caseInsensitive]) {
+            let totalMatches = totalRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = totalMatches.first, let totalRange = Range(match.range(at: 1), in: html) {
+                totalRuns = String(html[totalRange])
+                print("DEBUG - Extracted totalRuns: '\(totalRuns ?? "nil")' using simple pattern")
+            } else {
+                print("DEBUG - No total parkruns match found with simple pattern")
+            }
+        } else {
+            print("DEBUG - Failed to create simple total regex")
+        }
+        
+        // Look for event name in first <td><a> combination  
+        if let eventRegex = try? NSRegularExpression(pattern: #"<td><a[^>]*>([^<]+parkrun[^<]*)</a></td>"#, options: [.caseInsensitive]) {
+            let eventMatches = eventRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = eventMatches.first, let eventRange = Range(match.range(at: 1), in: html) {
+                lastEvent = String(html[eventRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+                print("DEBUG - Extracted lastEvent: '\(lastEvent ?? "nil")' using simple pattern")
+            }
+        }
+        
+        // Look for date pattern DD/MM/YYYY
+        if let dateRegex = try? NSRegularExpression(pattern: #"(\d{2}/\d{2}/\d{4})"#, options: []) {
+            let dateMatches = dateRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = dateMatches.first, let dateRange = Range(match.range(at: 1), in: html) {
+                lastDate = String(html[dateRange])
+                print("DEBUG - Extracted lastDate: '\(lastDate ?? "nil")' using simple pattern")
+            }
+        }
+        
+        // Look for time pattern MM:SS in table
+        if let timeRegex = try? NSRegularExpression(pattern: #"<td>(\d{2}:\d{2})</td>"#, options: []) {
+            let timeMatches = timeRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = timeMatches.first, let timeRange = Range(match.range(at: 1), in: html) {
+                lastTime = String(html[timeRange])
+                print("DEBUG - Extracted lastTime: '\(lastTime ?? "nil")' using simple pattern")
+            }
+        }
+        
+        // Look for event results URL from date link pattern
+        if let eventURLRegex = try? NSRegularExpression(pattern: #"<td><a href="(https://www\.parkrun\.(?:org\.uk|com|us|au|org\.nz|co\.za|it|se|dk|pl|ie|ca|fi|fr|sg|de|no|ru|my)/[^/]+/results/\d+/)"[^>]*>\d{2}/\d{2}/\d{4}</a></td>"#, options: [.caseInsensitive]) {
+            let urlMatches = eventURLRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+            if let match = urlMatches.first, let urlRange = Range(match.range(at: 1), in: html) {
+                lastEventURL = String(html[urlRange])
+                print("DEBUG - Extracted lastEventURL: '\(lastEventURL ?? "nil")' using corrected pattern with <td> wrapper")
+            }
+        }
+        
+        print("DEBUG - Final extracted data: name='\(name ?? "nil")', totalRuns='\(totalRuns ?? "nil")', lastEvent='\(lastEvent ?? "nil")', lastDate='\(lastDate ?? "nil")', lastTime='\(lastTime ?? "nil")', lastEventURL='\(lastEventURL ?? "nil")'")
+        return (name: name, totalRuns: totalRuns, lastDate: lastDate, lastTime: lastTime, lastEvent: lastEvent, lastEventURL: lastEventURL)
+    }
+
+    // MARK: - QR & Barcode Generation
+    private func generateQRCode(from string: String) -> UIImage? {
+        guard !string.isEmpty else { return nil }
+        qrCodeFilter.message = Data(string.utf8)
+        guard let ciImage = qrCodeFilter.outputImage else { return nil }
+        return convertToUIImage(from: ciImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10)))
+    }
+
+    private func generateBarcode(from string: String) -> UIImage? {
+        guard !string.isEmpty else { return nil }
+        barcodeFilter.message = Data(string.utf8)
+        guard let ciImage = barcodeFilter.outputImage else { return nil }
+        return convertToUIImage(from: ciImage.transformed(by: CGAffineTransform(scaleX: 2, y: 2)))
+    }
+
+    private func convertToUIImage(from ciImage: CIImage) -> UIImage? {
+        guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+#Preview {
+    do {
+        let previewContainer = try ModelContainer(for: ParkrunInfo.self, configurations: ModelConfiguration())
+        let context = previewContainer.mainContext
+        
+        // Insert sample data for preview
+        let previewParkrunInfo = ParkrunInfo(parkrunID: "A12345", name: "John Doe", homeParkrun: "Southampton Parkrun", country: Country.unitedKingdom.rawValue, isDefault: true)
+        context.insert(previewParkrunInfo)
+        
+        return MeTabView()
+            .modelContainer(previewContainer)
+            .environmentObject(NotificationManager.shared)
+    } catch {
+        return Text("Failed to create preview: \(error)")
+    }
+}

--- a/PR Bar Code/Views/MeTabView.swift
+++ b/PR Bar Code/Views/MeTabView.swift
@@ -158,7 +158,7 @@ struct MeTabView: View {
                 .padding()
                 .animation(AnimationConstants.springAnimation, value: isEditing)
             }
-            .navigationTitle("Me")
+            .navigationBarHidden(true)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if isEditing {

--- a/PR Bar Code/Views/SettingsTabView.swift
+++ b/PR Bar Code/Views/SettingsTabView.swift
@@ -1,0 +1,320 @@
+//
+//  SettingsTabView.swift
+//  PR Bar Code
+//
+//  Created by Claude Code on 15/06/2025.
+//
+
+import SwiftUI
+
+enum AppearanceMode: String, CaseIterable {
+    case system = "System"
+    case light = "Light"
+    case dark = "Dark"
+    
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system:
+            return nil
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        }
+    }
+}
+
+struct SettingsTabView: View {
+    @Environment(\.colorScheme) var systemColorScheme
+    @EnvironmentObject var notificationManager: NotificationManager
+    @AppStorage("appearanceMode") private var appearanceMode: String = AppearanceMode.system.rawValue
+    @State private var preferredColorScheme: ColorScheme?
+    
+    private var currentAppearanceMode: AppearanceMode {
+        AppearanceMode(rawValue: appearanceMode) ?? .system
+    }
+    
+    var body: some View {
+        NavigationView {
+            List {
+                // Notifications Section
+                Section {
+                    notificationPermissionRow
+                    
+                    if notificationManager.hasPermission {
+                        saturdayRemindersRow
+                        resultUpdatesRow
+                    }
+                } header: {
+                    Text("Notifications")
+                } footer: {
+                    if notificationManager.hasPermission {
+                        Text("Saturday reminders will notify you before parkrun starts. Result updates will let you know when new results may be available.")
+                    } else {
+                        Text("Enable notifications to receive parkrun reminders and result updates.")
+                    }
+                }
+                
+                // Appearance Section
+                Section {
+                    appearanceModeRow
+                } header: {
+                    Text("Appearance")
+                } footer: {
+                    Text("Choose how the app appears. System mode follows your device's appearance settings.")
+                }
+                
+                // App Information Section
+                Section {
+                    appVersionRow
+                    aboutRow
+                } header: {
+                    Text("About")
+                }
+            }
+            .navigationTitle("Settings")
+        }
+        .preferredColorScheme(preferredColorScheme)
+        .onAppear {
+            updateColorScheme()
+        }
+    }
+    
+    // MARK: - Notification Rows
+    
+    private var notificationPermissionRow: some View {
+        HStack {
+            Image(systemName: notificationManager.hasPermission ? "bell.fill" : "bell.slash")
+                .foregroundColor(notificationManager.hasPermission ? .green : .red)
+                .font(.title2)
+                .frame(width: 30)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Notification Permission")
+                    .font(.body)
+                    .fontWeight(.medium)
+                
+                Text(notificationManager.hasPermission ? "Enabled" : "Disabled")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            if !notificationManager.hasPermission {
+                Button("Enable") {
+                    Task {
+                        await notificationManager.requestNotificationPermission()
+                        if notificationManager.hasPermission {
+                            setupNotificationsForAllUsers()
+                        }
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+            }
+        }
+    }
+    
+    private var saturdayRemindersRow: some View {
+        HStack {
+            Image(systemName: "calendar.badge.clock")
+                .foregroundColor(.adaptiveParkrunGreen)
+                .font(.title2)
+                .frame(width: 30)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Saturday Reminders")
+                    .font(.body)
+                    .fontWeight(.medium)
+                
+                Text("Get reminded before parkrun starts")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            Toggle("", isOn: $notificationManager.isNotificationsEnabled)
+                .labelsHidden()
+                .onChange(of: notificationManager.isNotificationsEnabled) { oldValue, newValue in
+                    // Save the setting
+                    UserDefaults.standard.set(newValue, forKey: "isNotificationsEnabled")
+                    
+                    if newValue {
+                        notificationManager.scheduleSaturdayReminders()
+                        setupNotificationsForAllUsers()
+                    } else {
+                        notificationManager.cancelSaturdayReminders()
+                    }
+                }
+        }
+    }
+    
+    private var resultUpdatesRow: some View {
+        HStack {
+            Image(systemName: "bell.badge")
+                .foregroundColor(.adaptiveParkrunGreen)
+                .font(.title2)
+                .frame(width: 30)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Result Updates")
+                    .font(.body)
+                    .fontWeight(.medium)
+                
+                Text("Get notified when new results may be available")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .font(.title3)
+        }
+    }
+    
+    // MARK: - Appearance Rows
+    
+    private var appearanceModeRow: some View {
+        HStack {
+            Image(systemName: appearanceIcon)
+                .foregroundColor(.adaptiveParkrunGreen)
+                .font(.title2)
+                .frame(width: 30)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("App Appearance")
+                    .font(.body)
+                    .fontWeight(.medium)
+                
+                Text(currentAppearanceMode.rawValue)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            Menu {
+                ForEach(AppearanceMode.allCases, id: \.self) { mode in
+                    Button(action: {
+                        setAppearanceMode(mode)
+                    }) {
+                        HStack {
+                            Text(mode.rawValue)
+                            if mode == currentAppearanceMode {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Text(currentAppearanceMode.rawValue)
+                        .foregroundColor(.primary)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+    
+    // MARK: - App Info Rows
+    
+    private var appVersionRow: some View {
+        HStack {
+            Image(systemName: "info.circle")
+                .foregroundColor(.adaptiveParkrunGreen)
+                .font(.title2)
+                .frame(width: 30)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Version")
+                    .font(.body)
+                    .fontWeight(.medium)
+                
+                Text(appVersion)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+        }
+    }
+    
+    private var aboutRow: some View {
+        HStack {
+            Image(systemName: "heart.circle")
+                .foregroundColor(.adaptiveParkrunGreen)
+                .font(.title2)
+                .frame(width: 30)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("About 5K QR Code")
+                    .font(.body)
+                    .fontWeight(.medium)
+                
+                Text("Generate QR codes and barcodes for parkrun")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+        }
+    }
+    
+    // MARK: - Computed Properties
+    
+    private var appearanceIcon: String {
+        switch currentAppearanceMode {
+        case .system:
+            return systemColorScheme == .dark ? "circle.lefthalf.filled" : "circle.righthalf.filled"
+        case .light:
+            return "sun.max"
+        case .dark:
+            return "moon"
+        }
+    }
+    
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+        return "\(version) (\(build))"
+    }
+    
+    // MARK: - Functions
+    
+    private func setAppearanceMode(_ mode: AppearanceMode) {
+        appearanceMode = mode.rawValue
+        updateColorScheme()
+    }
+    
+    private func updateColorScheme() {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            preferredColorScheme = currentAppearanceMode.colorScheme
+        }
+    }
+    
+    private func setupNotificationsForAllUsers() {
+        // This function would set up notifications for all users
+        // For now, we'll just trigger Saturday reminders
+        guard notificationManager.hasPermission else { return }
+        
+        if notificationManager.isNotificationsEnabled {
+            notificationManager.scheduleSaturdayReminders()
+        }
+        
+        print("Notifications set up for all users")
+    }
+}
+
+#Preview {
+    SettingsTabView()
+        .environmentObject(NotificationManager.shared)
+}


### PR DESCRIPTION
## Summary
• Implement complete app restructure with TabView-based navigation featuring 4 tabs: Me, Family & Friends, Events, Settings
• Move multi-user management to dedicated Family tab with card-based layout and comprehensive user controls
• Create Me tab focused on default user only with streamlined QR code access and personal information
• Add Events tab with "coming soon" placeholder for future event discovery features
• Consolidate notifications and dark mode settings into dedicated Settings tab
• Fix QR sheet presentation bug that caused blank screen on first tap
• Resolve data corruption issues with user names and default user assignments

## Test plan
- [x] Verify all 4 tabs load correctly and maintain state
- [x] Test Family tab multi-user management (add, delete, set default, QR access)
- [x] Confirm Me tab shows only default user with edit functionality
- [x] Validate QR code generation works in both tabs without blank screen bug
- [x] Test Settings tab notifications and dark mode controls
- [x] Verify data persistence across app launches and tab switches
- [x] Confirm iOS and watchOS builds complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)