### PR TITLE
Clean up OnboardingView: use parkrun green colors and remove hamburger menu

### DIFF
--- a/PR Bar Code/Views/OnboardingView.swift
+++ b/PR Bar Code/Views/OnboardingView.swift
@@ -38,7 +38,7 @@ struct OnboardingView: View {
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .padding()
-                            .background(Color.blue)
+                            .background(Color.adaptiveParkrunGreen)
                             .cornerRadius(12)
                     }
                     
@@ -56,16 +56,6 @@ struct OnboardingView: View {
             }
             .navigationTitle("Me")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: {
-                        // Hamburger menu placeholder
-                    }) {
-                        Image(systemName: "line.horizontal.3")
-                            .foregroundColor(.blue)
-                    }
-                }
-            }
         }
         .sheet(isPresented: $showBarcodeEntry) {
             BarcodeEntryView(isPresented: $showBarcodeEntry, onboardingPresented: $isPresented)
@@ -112,7 +102,7 @@ struct BarcodeEntryView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(barcodeText.isEmpty ? Color.gray : Color.blue)
+                    .background(barcodeText.isEmpty ? Color.gray : Color.adaptiveParkrunGreen)
                     .cornerRadius(12)
                 }
                 .disabled(barcodeText.isEmpty || isLoading)


### PR DESCRIPTION
## Summary
- Update button colors in OnboardingView to use consistent parkrun green
- Remove non-functional hamburger menu button from onboarding flow

## Changes Made
### OnboardingView.swift
- **"Add barcode" button**: Changed from `Color.blue` to `Color.adaptiveParkrunGreen`
- **"Search" button**: Changed from `Color.blue` to `Color.adaptiveParkrunGreen`
- **Hamburger menu**: Removed non-functional placeholder button from toolbar

## Benefits
✅ **Color Consistency**: All buttons now use the same parkrun green as rest of UI
✅ **Cleaner UX**: Removes confusing non-functional hamburger menu from onboarding
✅ **Simplified Interface**: Focuses user attention on the actual onboarding actions

## Visual Impact
The onboarding flow now maintains visual consistency with the rest of the app's parkrun branding, while removing unnecessary UI elements that could confuse new users.

🤖 Generated with [Claude Code](https://claude.ai/code)