### PR TITLE
Fix Mia Gardner total parkruns not displaying (junior parkrun regex issue)

### DIFF
--- a/PR Bar Code/Views/FamilyTabView.swift
+++ b/PR Bar Code/Views/FamilyTabView.swift
@@ -194,6 +194,7 @@ struct FamilyTabView: View {
         do {
             try modelContext.save()
             
+            print("DEBUG - Added new user \(parkrunID), now fetching data...")
             // Fetch data for the new user in background
             fetchParkrunnerName(for: newUser)
             
@@ -256,7 +257,11 @@ struct FamilyTabView: View {
         let numericId = String(user.parkrunID.dropFirst())
         
         let urlString = "https://www.parkrun.org.uk/parkrunner/\(numericId)/"
-        guard let url = URL(string: urlString) else { return }
+        print("DEBUG - Starting fetch for \(user.parkrunID) at URL: \(urlString)")
+        guard let url = URL(string: urlString) else { 
+            print("DEBUG - Invalid URL for \(user.parkrunID): \(urlString)")
+            return 
+        }
         
         // Create request with proper headers to avoid 403
         var request = URLRequest(url: url)
@@ -288,24 +293,40 @@ struct FamilyTabView: View {
             // Parse the HTML to extract all information
             let extractedData = extractParkrunnerDataFromHTML(htmlString)
             
+            print("DEBUG - Extracted data for \(user.parkrunID):")
+            print("  - Name: \(extractedData.name ?? "nil")")
+            print("  - Total runs: \(extractedData.totalRuns ?? "nil")")
+            print("  - Last date: \(extractedData.lastDate ?? "nil")")
+            print("  - Last time: \(extractedData.lastTime ?? "nil")")
+            print("  - Last event: \(extractedData.lastEvent ?? "nil")")
+            print("  - Last event URL: \(extractedData.lastEventURL ?? "nil")")
+            
             DispatchQueue.main.async {
+                print("DEBUG - Updating user data for \(user.parkrunID)")
+                
                 // Update user data
                 if let name = extractedData.name {
+                    print("DEBUG - Setting name: '\(user.name)' -> '\(name)'")
                     user.name = name
                 }
                 if let totalRuns = extractedData.totalRuns {
+                    print("DEBUG - Setting totalParkruns: '\(user.totalParkruns ?? "nil")' -> '\(totalRuns)'")
                     user.totalParkruns = totalRuns
                 }
                 if let lastDate = extractedData.lastDate {
+                    print("DEBUG - Setting lastParkrunDate: '\(user.lastParkrunDate ?? "nil")' -> '\(lastDate)'")
                     user.lastParkrunDate = lastDate
                 }
                 if let lastTime = extractedData.lastTime {
+                    print("DEBUG - Setting lastParkrunTime: '\(user.lastParkrunTime ?? "nil")' -> '\(lastTime)'")
                     user.lastParkrunTime = lastTime
                 }
                 if let lastEvent = extractedData.lastEvent {
+                    print("DEBUG - Setting lastParkrunEvent: '\(user.lastParkrunEvent ?? "nil")' -> '\(lastEvent)'")
                     user.lastParkrunEvent = lastEvent
                 }
                 if let lastEventURL = extractedData.lastEventURL {
+                    print("DEBUG - Setting lastParkrunEventURL: '\(user.lastParkrunEventURL ?? "nil")' -> '\(lastEventURL)'")
                     user.lastParkrunEventURL = lastEventURL
                 }
                 
@@ -315,9 +336,16 @@ struct FamilyTabView: View {
                 // Save the updated data
                 do {
                     try self.modelContext.save()
-                    print("Updated data for user: \(user.parkrunID)")
+                    print("DEBUG - Successfully saved data for user: \(user.parkrunID)")
+                    print("DEBUG - Final saved values:")
+                    print("  - Name: '\(user.name)'")
+                    print("  - TotalParkruns: '\(user.totalParkruns ?? "nil")'")
+                    print("  - LastDate: '\(user.lastParkrunDate ?? "nil")'")
+                    print("  - LastTime: '\(user.lastParkrunTime ?? "nil")'")
+                    print("  - LastEvent: '\(user.lastParkrunEvent ?? "nil")'")
+                    print("  - LastEventURL: '\(user.lastParkrunEventURL ?? "nil")'")
                 } catch {
-                    print("Failed to save updated data for user \(user.parkrunID): \(error)")
+                    print("DEBUG - Failed to save updated data for user \(user.parkrunID): \(error)")
                 }
             }
         }.resume()

--- a/PR Bar Code/Views/MeTabView.swift
+++ b/PR Bar Code/Views/MeTabView.swift
@@ -1027,18 +1027,18 @@ struct MeTabView: View {
             print("DEBUG - Failed to create name regex")
         }
         
-        // Extract total parkruns from h3 tag: <h3>279 parkruns total</h3>
-        // Try simpler pattern first
-        if let totalRegex = try? NSRegularExpression(pattern: #"(\d+)\s+parkruns?\s+total"#, options: [.caseInsensitive]) {
+        // Extract total parkruns from h3 tag: <h3>279 parkruns total</h3> or <h3>50 parkruns & 1 junior parkrun total</h3>
+        // Use pattern that handles both regular and junior parkrun cases
+        if let totalRegex = try? NSRegularExpression(pattern: #"(\d+)\s+parkruns?(?:\s+&\s+\d+\s+junior\s+parkrun)?\s+total"#, options: [.caseInsensitive]) {
             let totalMatches = totalRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
             if let match = totalMatches.first, let totalRange = Range(match.range(at: 1), in: html) {
                 totalRuns = String(html[totalRange])
-                print("DEBUG - Extracted totalRuns: '\(totalRuns ?? "nil")' using simple pattern")
+                print("DEBUG - Extracted totalRuns: '\(totalRuns ?? "nil")' using improved pattern")
             } else {
-                print("DEBUG - No total parkruns match found with simple pattern")
+                print("DEBUG - No total parkruns match found with improved pattern")
             }
         } else {
-            print("DEBUG - Failed to create simple total regex")
+            print("DEBUG - Failed to create improved total regex")
         }
         
         // Look for event name in first <td><a> combination  


### PR DESCRIPTION
## Summary
Fixes bug where Mia Gardner's total parkruns count was not being extracted or displayed in the Family & Friends tab.

## Root Cause
MeTabView was using a simple regex pattern that couldn't handle parkrun profiles with junior parkruns:
- **Mia Gardner's HTML**: `<h3>50 parkruns & 1 junior parkrun total</h3>`
- **Old regex**: `(\d+)\s+parkruns?\s+total` ❌
- **Issue**: Pattern only matched "X parkruns total" but not "X parkruns & Y junior parkrun total"

## Solution
Updated MeTabView to use the same robust regex pattern as FamilyTabView:
- **New regex**: `(\d+)\s+parkruns?(?:\s+&\s+\d+\s+junior\s+parkrun)?\s+total` ✅
- **Handles both formats**:
  - Regular: "279 parkruns total" (Matt Gardner)
  - Junior: "50 parkruns & 1 junior parkrun total" (Mia Gardner)

## Testing Results
✅ **Unit tests passing**: Mia Gardner HTML parsing test extracts "50" correctly
✅ **Manual testing**: Regex works for both Matt and Mia's HTML formats
✅ **Debug logging**: Added comprehensive debugging to track data extraction flow

## Debug Output (Before Fix)
```
DEBUG - No total parkruns match found with simple pattern
```

## Debug Output (After Fix)
```
DEBUG - Extracted totalRuns: '50' using improved pattern
```

## Impact
- Mia Gardner's total parkruns will now display correctly as "50 runs"
- Maintains compatibility with all existing users (Matt Gardner, etc.)
- Consistent regex patterns across FamilyTabView and MeTabView

🤖 Generated with [Claude Code](https://claude.ai/code)