### PR TITLE
Update Family & Friends layout: remove nav title and align to top

### DIFF
--- a/PR Bar Code/Views/FamilyTabView.swift
+++ b/PR Bar Code/Views/FamilyTabView.swift
@@ -24,7 +24,7 @@ struct FamilyTabView: View {
     
     var body: some View {
         NavigationView {
-            VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 20) {
                 if parkrunInfoList.isEmpty {
                     // Empty state
                     VStack(spacing: 20) {
@@ -59,31 +59,40 @@ struct FamilyTabView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(Color(.systemGroupedBackground))
                 } else {
-                    // Results table
-                    List {
-                        ForEach(availableUsers, id: \.parkrunID) { user in
-                            FamilyUserCard(
-                                user: user,
-                                onTapQR: {
-                                    selectedUserForQR = user
-                                },
-                                onDelete: {
-                                    deleteUser(user)
-                                },
-                                onSetDefault: {
-                                    setDefaultUser(user)
-                                },
-                                canDelete: parkrunInfoList.count > 1
-                            )
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                    // Family & Friends Card
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Family & Friends")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.adaptiveParkrunGreen)
+                        
+                        // Results table
+                        VStack(spacing: 8) {
+                            ForEach(availableUsers, id: \.parkrunID) { user in
+                                FamilyUserCard(
+                                    user: user,
+                                    onTapQR: {
+                                        selectedUserForQR = user
+                                    },
+                                    onDelete: {
+                                        deleteUser(user)
+                                    },
+                                    onSetDefault: {
+                                        setDefaultUser(user)
+                                    },
+                                    canDelete: parkrunInfoList.count > 1
+                                )
+                            }
                         }
                     }
-                    .listStyle(PlainListStyle())
+                    .cardStyle()
                 }
+                
+                Spacer()
             }
-            .navigationTitle("Family & Friends")
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding()
+            .background(Color(.systemGroupedBackground))
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     HStack {


### PR DESCRIPTION
## Summary
Improves the Family & Friends page layout by removing the redundant navigation title and aligning content to the top with a clean card-based design.

## Changes Made

### 1. Navigation Improvements
- **Removed Navigation Title**: Eliminated redundant "Family & Friends" from navigation bar
- **Cleaner Header**: Navigation bar now shows only the essential toolbar buttons

### 2. Layout Improvements  
- **Top Alignment**: Content now aligns to top-left instead of being centered
- **Better Space Usage**: More efficient use of screen real estate
- **Spacer Added**: Proper spacing to push content to top of screen

### 3. Visual Design
- **Card Layout**: Green "Family & Friends" title within white card container
- **Consistent Styling**: Matches the Me page card-based design pattern
- **Visual Hierarchy**: Clear section organization with green title

## Benefits

✅ **Cleaner Navigation**: No duplicate title reduces visual clutter  
✅ **Better UX**: Content starts at top for immediate access  
✅ **Consistent Design**: Follows same patterns as Me page  
✅ **Improved Spacing**: More room for family member cards  
✅ **Professional Look**: Card-based layout with proper typography

## Visual Impact
The Family & Friends page now has a more professional, organized appearance that matches the rest of the app's design language while providing better usability.

🤖 Generated with [Claude Code](https://claude.ai/code)