### PR TITLE
Add reversed parkrun QR icon asset

### DIFF
--- a/PR Bar Code/Assets/parkrun_qr_icon_reversed.svg
+++ b/PR Bar Code/Assets/parkrun_qr_icon_reversed.svg
@@ -1,0 +1,111 @@
+<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background rounded square -->
+  <rect x="0" y="0" width="1024" height="1024" rx="200" ry="200" fill="#2D4A22"/>
+  
+  <!-- QR Code -->
+  <g transform="translate(212, 212)">
+    <!-- QR code background -->
+    <rect x="0" y="0" width="600" height="600" fill="#2D4A22"/>
+    
+    <!-- Top-left corner -->
+    <rect x="0" y="0" width="168" height="168" fill="#B8D477"/>
+    <rect x="24" y="24" width="120" height="120" fill="#2D4A22"/>
+    <rect x="48" y="48" width="72" height="72" fill="#B8D477"/>
+    
+    <!-- Top-right corner -->
+    <rect x="432" y="0" width="168" height="168" fill="#B8D477"/>
+    <rect x="456" y="24" width="120" height="120" fill="#2D4A22"/>
+    <rect x="480" y="48" width="72" height="72" fill="#B8D477"/>
+    
+    <!-- Bottom-left corner -->
+    <rect x="0" y="432" width="168" height="168" fill="#B8D477"/>
+    <rect x="24" y="456" width="120" height="120" fill="#2D4A22"/>
+    <rect x="48" y="480" width="72" height="72" fill="#B8D477"/>
+    
+    <!-- Timing pattern -->
+    <rect x="192" y="24" width="24" height="24" fill="#B8D477"/>
+    <rect x="240" y="24" width="24" height="24" fill="#B8D477"/>
+    <rect x="288" y="24" width="24" height="24" fill="#B8D477"/>
+    <rect x="336" y="24" width="24" height="24" fill="#B8D477"/>
+    <rect x="384" y="24" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="24" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="24" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="24" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="24" y="336" width="24" height="24" fill="#B8D477"/>
+    <rect x="24" y="384" width="24" height="24" fill="#B8D477"/>
+    
+    <!-- Data modules pattern -->
+    <rect x="192" y="72" width="24" height="24" fill="#B8D477"/>
+    <rect x="240" y="72" width="24" height="24" fill="#B8D477"/>
+    <rect x="312" y="72" width="24" height="24" fill="#B8D477"/>
+    <rect x="384" y="72" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="72" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="120" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="192" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="240" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="288" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="384" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="432" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="480" y="192" width="24" height="24" fill="#B8D477"/>
+    <rect x="552" y="192" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="96" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="168" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="216" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="288" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="336" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="408" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="456" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="528" y="240" width="24" height="24" fill="#B8D477"/>
+    <rect x="576" y="240" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="72" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="144" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="240" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="312" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="384" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="456" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="504" y="288" width="24" height="24" fill="#B8D477"/>
+    <rect x="552" y="288" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="120" y="336" width="24" height="24" fill="#B8D477"/>
+    <rect x="192" y="336" width="24" height="24" fill="#B8D477"/>
+    <rect x="264" y="336" width="24" height="24" fill="#B8D477"/>
+    <rect x="336" y="336" width="24" height="24" fill="#B8D477"/>
+    <rect x="408" y="336" width="24" height="24" fill="#B8D477"/>
+    <rect x="480" y="336" width="24" height="24" fill="#B8D477"/>
+    <rect x="528" y="336" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="96" y="384" width="24" height="24" fill="#B8D477"/>
+    <rect x="168" y="384" width="24" height="24" fill="#B8D477"/>
+    <rect x="216" y="384" width="24" height="24" fill="#B8D477"/>
+    <rect x="288" y="384" width="24" height="24" fill="#B8D477"/>
+    <rect x="360" y="384" width="24" height="24" fill="#B8D477"/>
+    <rect x="432" y="384" width="24" height="24" fill="#B8D477"/>
+    <rect x="504" y="384" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="192" y="480" width="24" height="24" fill="#B8D477"/>
+    <rect x="240" y="480" width="24" height="24" fill="#B8D477"/>
+    <rect x="312" y="480" width="24" height="24" fill="#B8D477"/>
+    <rect x="384" y="480" width="24" height="24" fill="#B8D477"/>
+    <rect x="456" y="480" width="24" height="24" fill="#B8D477"/>
+    <rect x="528" y="480" width="24" height="24" fill="#B8D477"/>
+    <rect x="576" y="480" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="216" y="528" width="24" height="24" fill="#B8D477"/>
+    <rect x="288" y="528" width="24" height="24" fill="#B8D477"/>
+    <rect x="360" y="528" width="24" height="24" fill="#B8D477"/>
+    <rect x="432" y="528" width="24" height="24" fill="#B8D477"/>
+    <rect x="480" y="528" width="24" height="24" fill="#B8D477"/>
+    <rect x="552" y="528" width="24" height="24" fill="#B8D477"/>
+    
+    <rect x="192" y="576" width="24" height="24" fill="#B8D477"/>
+    <rect x="264" y="576" width="24" height="24" fill="#B8D477"/>
+    <rect x="336" y="576" width="24" height="24" fill="#B8D477"/>
+    <rect x="408" y="576" width="24" height="24" fill="#B8D477"/>
+    <rect x="480" y="576" width="24" height="24" fill="#B8D477"/>
+    <rect x="528" y="576" width="24" height="24" fill="#B8D477"/>
+  </g>
+</svg> 


### PR DESCRIPTION
## Summary
- Add parkrun_qr_icon_reversed.svg to Assets directory
- Provides alternative branding option for improved visual consistency
- SVG format ensures scalability across different UI contexts

## Test plan
- [x] Verify file is properly tracked in git
- [x] Confirm asset is accessible in project structure

🤖 Generated with [Claude Code](https://claude.ai/code)