### PR TITLE
feat: restructure app navigation with dedicated Journey tab

### DIFF
--- a/PR Bar Code/Views/Charts/ParkrunVisualizationsView.swift
+++ b/PR Bar Code/Views/Charts/ParkrunVisualizationsView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ParkrunVisualizationsView: View {
     let parkrunInfo: ParkrunInfo
     @State private var selectedTab = 0
-    @State private var isExpanded = false
     
     private let tabs = [
         ("Overview", "chart.bar"),
@@ -23,103 +22,64 @@ struct ParkrunVisualizationsView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            // Header with expand/collapse
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("parkrun Journey")
-                        .font(.title2)
-                        .fontWeight(.bold)
-                        .foregroundColor(.primary)
-                    
-                    if parkrunInfo.totalParkrunsInt > 0 {
-                        Text("\(parkrunInfo.totalParkrunsInt) parkruns • \(parkrunInfo.uniqueVenuesCount) venues")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    } else {
-                        Text("Visualizations will appear once data is available")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                
-                Spacer()
-                
-                Button(action: {
-                    withAnimation(.spring()) {
-                        isExpanded.toggle()
-                    }
-                }) {
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .font(.title3)
-                        .foregroundColor(.adaptiveParkrunGreen)
-                }
-            }
-            .padding()
-            .background(Color.adaptiveCardBackground)
-            .cornerRadius(12, corners: isExpanded ? [.topLeft, .topRight] : .allCorners)
-            
-            if isExpanded {
-                VStack(spacing: 0) {
-                    if parkrunInfo.totalParkrunsInt > 0 {
-                        // Tab selector
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 8) {
-                                ForEach(tabs.indices, id: \.self) { index in
-                                    TabButton(
-                                        title: tabs[index].0,
-                                        icon: tabs[index].1,
-                                        isSelected: selectedTab == index
-                                    ) {
-                                        withAnimation(.easeInOut(duration: 0.3)) {
-                                            selectedTab = index
-                                        }
-                                    }
+            if parkrunInfo.totalParkrunsInt > 0 {
+                // Tab selector
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(tabs.indices, id: \.self) { index in
+                            TabButton(
+                                title: tabs[index].0,
+                                icon: tabs[index].1,
+                                isSelected: selectedTab == index
+                            ) {
+                                withAnimation(.easeInOut(duration: 0.3)) {
+                                    selectedTab = index
                                 }
                             }
-                            .padding(.horizontal)
                         }
-                        .padding(.vertical, 12)
-                        .background(Color.adaptiveCardBackground)
-                        
-                        // Content
-                        ScrollView {
-                            contentView
-                                .padding()
-                        }
-                        .frame(maxHeight: 600)
-                    } else {
-                        // Empty state
-                        VStack(spacing: 16) {
-                            Image(systemName: "chart.bar.xaxis")
-                                .font(.system(size: 48))
-                                .foregroundColor(.gray)
-                            
-                            VStack(spacing: 8) {
-                                Text("No Visualization Data")
-                                    .font(.headline)
-                                    .foregroundColor(.primary)
-                                
-                                Text("Complete your first parkrun or refresh your data to see detailed visualizations of your parkrun journey.")
-                                    .font(.body)
-                                    .foregroundColor(.secondary)
-                                    .multilineTextAlignment(.center)
-                            }
-                            
-                            Button("Refresh Data") {
-                                // Trigger data refresh
-                                refreshVisualizationData()
-                            }
-                            .buttonStyle(.borderedProminent)
-                        }
-                        .padding(40)
                     }
+                    .padding(.horizontal)
+                }
+                .padding(.vertical, 12)
+                .background(Color.adaptiveCardBackground)
+                .cornerRadius(12, corners: [.topLeft, .topRight])
+                
+                // Content
+                ScrollView {
+                    contentView
+                        .padding()
                 }
                 .background(Color.adaptiveCardBackground)
                 .cornerRadius(12, corners: [.bottomLeft, .bottomRight])
+            } else {
+                // Empty state
+                VStack(spacing: 16) {
+                    Image(systemName: "chart.bar.xaxis")
+                        .font(.system(size: 48))
+                        .foregroundColor(.gray)
+                    
+                    VStack(spacing: 8) {
+                        Text("No Visualization Data")
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                        
+                        Text("Complete your first parkrun or refresh your data to see detailed visualizations of your parkrun journey.")
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    
+                    Button("Refresh Data") {
+                        // Trigger data refresh
+                        refreshVisualizationData()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(40)
+                .background(Color.adaptiveCardBackground)
+                .cornerRadius(12)
             }
         }
-        .background(Color.adaptiveCardBackground)
-        .cornerRadius(12)
         .shadow(radius: 2)
     }
     

--- a/PR Bar Code/Views/JourneyTabView.swift
+++ b/PR Bar Code/Views/JourneyTabView.swift
@@ -1,0 +1,84 @@
+//
+//  JourneyTabView.swift
+//  PR Bar Code
+//
+//  Created by Claude Code on 09/07/2025.
+//
+
+import SwiftUI
+import SwiftData
+
+struct JourneyTabView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var parkrunInfoList: [ParkrunInfo]
+    
+    // Get default user only
+    private var defaultUser: ParkrunInfo? {
+        if let defaultUser = parkrunInfoList.first(where: { $0.isDefault }) {
+            return defaultUser
+        }
+        return parkrunInfoList.first
+    }
+    
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 20) {
+                    if let user = defaultUser {
+                        // Journey visualizations without expand/collapse
+                        ParkrunVisualizationsView(parkrunInfo: user)
+                    } else {
+                        // Empty state when no user data
+                        VStack(spacing: 20) {
+                            Image(systemName: "chart.bar.xaxis")
+                                .font(.system(size: 60))
+                                .foregroundColor(.gray)
+                            
+                            VStack(spacing: 8) {
+                                Text("No Journey Data")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.primary)
+                                
+                                Text("Set up your parkrun profile in the Me tab to view your journey visualizations and progress.")
+                                    .font(.body)
+                                    .foregroundColor(.secondary)
+                                    .multilineTextAlignment(.center)
+                            }
+                        }
+                        .padding(40)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Journey")
+            .navigationBarTitleDisplayMode(.large)
+        }
+    }
+}
+
+#Preview {
+    do {
+        let previewContainer = try ModelContainer(for: ParkrunInfo.self, configurations: ModelConfiguration())
+        let context = previewContainer.mainContext
+        
+        // Insert sample data for preview
+        let previewParkrunInfo = ParkrunInfo(
+            parkrunID: "A79156",
+            name: "Matt GARDNER", 
+            homeParkrun: "Whiteley parkrun",
+            country: 826,
+            totalParkruns: "283",
+            lastParkrunDate: "05/07/2025",
+            lastParkrunTime: "24:24",
+            lastParkrunEvent: "Whiteley parkrun",
+            lastParkrunEventURL: "https://www.parkrun.org.uk/whiteley/results/331/"
+        )
+        context.insert(previewParkrunInfo)
+        
+        return JourneyTabView()
+            .modelContainer(previewContainer)
+    } catch {
+        return Text("Failed to create preview: \(error)")
+    }
+}

--- a/PR Bar Code/Views/MainTabView.swift
+++ b/PR Bar Code/Views/MainTabView.swift
@@ -32,11 +32,11 @@ struct MainTabView: View {
                 }
                 .tag(1)
             
-            // Events Tab - Placeholder for future features
-            EventsTabView()
+            // Journey Tab - parkrun journey visualizations
+            JourneyTabView()
                 .tabItem {
-                    Image(systemName: "calendar.circle")
-                    Text("Events")
+                    Image(systemName: "chart.line.uptrend.xyaxis.circle")
+                    Text("Journey")
                 }
                 .tag(2)
             

--- a/PR Bar Code/Views/MeTabView.swift
+++ b/PR Bar Code/Views/MeTabView.swift
@@ -129,11 +129,6 @@ struct MeTabView: View {
                         .cardStyle()
                         .transition(AnimationConstants.cardTransition)
                         
-                        // parkrun Journey Visualizations (also show in editing mode)
-                        if let user = defaultUser {
-                            ParkrunVisualizationsView(parkrunInfo: user)
-                                .transition(AnimationConstants.cardTransition)
-                        }
                         
                     } else {
                         // Display Default User Data
@@ -175,11 +170,6 @@ struct MeTabView: View {
                             }
                             .cardStyle()
                             
-                            // parkrun Journey Visualizations
-                            if let user = defaultUser {
-                                ParkrunVisualizationsView(parkrunInfo: user)
-                                    .transition(AnimationConstants.cardTransition)
-                            }
                         }
                         .transition(AnimationConstants.slideTransition)
                     }


### PR DESCRIPTION
- Replace Events tab with Journey tab for parkrun visualizations
- Create dedicated JourneyTabView with full-screen journey analytics
- Remove expand/collapse functionality from ParkrunVisualizationsView
- Optimize MeTabView by removing journey components for cleaner focus
- Improve navigation UX with clear separation of personal data vs analytics

🤖 Generated with [Claude Code](https://claude.ai/code)